### PR TITLE
Changelog for TLS 1.2 (previous PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Require TLS 1.2 or above.
+
 ## [0.1.1] - 2020-07-06
 
 ### Added


### PR DESCRIPTION
To fix a linting issue in https://github.com/giantswarm/k8s-api-healthz/pull/17, I added enforcing a minimum TLS version of 1.2, but forgot to add it to the changelog