### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ workflows:
               only: /^v.*/
 
       - architect/upload-release-assets:
+          binary: k8s-api-healthz
           context: architect
           name: upload-release-assets
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@9.0.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   build:
@@ -10,6 +10,7 @@ workflows:
           context: architect
           name: go-build
           binary: k8s-api-healthz
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           filters:
             tags:
               only: /^v.*/
@@ -19,7 +20,18 @@ workflows:
           name: push-to-registries
           requires:
             - go-build
+          platforms: "linux/amd64,linux/arm64"
           filters:
             tags:
               only: /^v.*/
 
+      - architect/upload-release-assets:
+          context: architect
+          name: upload-release-assets
+          requires:
+            - go-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `k8s-api-healthz-windows-<arch>.exe`.
+
 ## [0.2.0] - 2023-03-06
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.23
 
+ARG TARGETARCH
+
 RUN apk add --no-cache ca-certificates
 
-ADD ./k8s-api-healthz  /k8s-api-healthz 
+COPY ./k8s-api-healthz-linux-${TARGETARCH}  /k8s-api-healthz 
 
 ENTRYPOINT ["/k8s-api-healthz"]


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.

Same pattern as giantswarm/muster#796.